### PR TITLE
Fixes incorrect error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,8 @@ var fs = require('fs'),
 
 function run (datafile, str, callback) {
   exec('jq \'' + str + '\' ' + datafile, function (err, stdout, stderr) {
-    if (stderr) {
-      callback(null, stderr);
-    }
-    else {
-      callback(null, stdout);
-    }
+    var errorMessage = err && err.message;
+    callback(errorMessage || stderr, stdout);
   });
 }
 
@@ -70,8 +66,8 @@ function runOne (problem, callback) {
       case 'data?':   writeAndPrompt(dataset); break;
       default:
         async.parallel({
-          expected: _.partial(run, datafile, solution),
-          actual: _.partial(run, datafile, answer)
+          actual: _.partial(run, datafile, answer),
+          expected: _.partial(run, datafile, solution)
         }, function (err, results) {
 
           if (err) {


### PR DESCRIPTION
Issue here was failing to handle the error case. I got the initial bug by running on a machine that didn't have jq installed, meaning both the expected and the actual returned "command 'jq blah' not found", which is the same string and therefore equal, shockingly 😅

Fixed it to handle either thrown errors or stderr and pass them to the error argument of the callback which seems correct, unless the intention is to show stderr output as a successful run (that will not match the expected output)?