### PR TITLE
Introduce running via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12-alpine
+RUN apk add --no-cache jq
+RUN npm install -g jq-tutorial
+ENTRYPOINT ["jq-tutorial"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Run individual lessons by name:
 
     $ jq-tutorial pick
 
+#### Running in docker
+
+    $ docker build -t jq-tutorial .
+    $ docker run -ti jq-tutorial
+
 ### Attribution
 
   * jq copyright (C) 2012 [Stephen Dolan][3]


### PR DESCRIPTION
Introduce the possibility to run jq-tutorial in docker. Useful for people without npm.